### PR TITLE
Middlewares to show django-silk profiling data for all requests

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-Django==3.2.5
+Django==3.2.6
 attrs==21.2.0
 pluggy==0.13.1
 py==1.10.0
@@ -7,3 +7,5 @@ pytest-cov==2.12.1
 pytest-django==4.4.0
 pytz==2021.1
 six==1.16.0
+# replace with pip when v4.1.1 is available for django-silk on pip
+git+https://github.com/jazzband/django-silk.git#egg=django-silk  # https://github.com/jazzband/django-silk

--- a/server_timing/middleware.py
+++ b/server_timing/middleware.py
@@ -22,10 +22,14 @@ def add_service(service):
 
 
 class TimedService(object):
-    def __init__(self, name, description=''):
+    def __init__(self, name, description="", duration=None):
         self.name = name
         self.description = description
+        self._duration = duration
         self._start = self._end = None
+
+        if self._duration:
+            add_service(self)
 
     def start(self):
         self._start = time.time()
@@ -36,6 +40,8 @@ class TimedService(object):
 
     @property
     def duration(self):
+        if not self._start and self._duration:
+            return self._duration
         return int(((self._end or time.time()) - self._start) * 1000)
 
 

--- a/server_timing/silk.py
+++ b/server_timing/silk.py
@@ -1,0 +1,45 @@
+from .middleware import TimedService, timed
+
+class ServerTimingSilkMiddleware:
+    """
+    This middleware will measure the response time for each request,
+    and also the time taken for sql queries, if silk is enabled.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def _get_query_timing(self, request):
+        try:
+            from silk.collector import DataCollector
+            from silk.profiling.profiler import silk_meta_profiler, silk_profile
+        except ModuleNotFoundError:
+            return
+        if not hasattr(request, 'silk_is_intercepted'):
+            return
+        with silk_meta_profiler():
+            collector = DataCollector()
+            silk_request = collector.request
+            if silk_request:
+                TimedService(
+                    name="sql",
+                    description="DB Queries",
+                    duration=sum([s.time_taken for s in silk_request.queries.all()]),
+                )
+
+    def __call__(self, request):
+        with timed("request-response", "Request Response"):
+            response = self.get_response(request)
+        self._get_query_timing(request)
+        return response
+
+
+class ServerTimingSilkViewOnlyMiddleware(ServerTimingSilkMiddleware):
+    """
+    This middleware would be put as the last middleware, to measure the
+    response time of only the underlying view.
+    """
+    def __call__(self, request):
+        with timed("request-view", "Request View"):
+            response = self.get_response(request)
+        self._get_query_timing(request)
+        return response

--- a/server_timing/silk.py
+++ b/server_timing/silk.py
@@ -33,13 +33,15 @@ class ServerTimingSilkMiddleware:
         return response
 
 
-class ServerTimingSilkViewOnlyMiddleware(ServerTimingSilkMiddleware):
+class ServerTimingSilkViewOnlyMiddleware:
     """
     This middleware would be put as the last middleware, to measure the
     response time of only the underlying view.
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
     def __call__(self, request):
         with timed("request-view", "Request View"):
             response = self.get_response(request)
-        self._get_query_timing(request)
         return response


### PR DESCRIPTION
Added a `duration` params to `TimedService` so that the duration could be set without calling `start()` and `end()` in cases where it is already calculated.

Using the same, created 2 middlewares to add the data from [django-silk](https://github.com/jazzband/django-silk)
- `ServerTimingSilkMiddleware` to add `Response Request` and `DB Queries` to the headers with respective timing values.
- `ServerTimingSilkViewOnlyMiddleware` to add `Response View` which when place last in the `MIDDLEWARES` settings, would measure the timing without the effect of other middlewares.

Fixes #18 